### PR TITLE
Couple items from your cryptpwutil wishlist

### DIFF
--- a/lib/Crypt/Password/Util.pm
+++ b/lib/Crypt/Password/Util.pm
@@ -19,31 +19,37 @@ our %CRYPT_TYPES = (
         summary => 'A baroque passphrase scheme based on MD5, designed by Poul-Henning Kamp and originally implemented in FreeBSD',
         re => qr/\A (\$ (?:apr)?1 \$) ($b64d {0,8}) \$ ($b64d {22}) \z/x,
         re_summary => '$1$ or $apr1$ header',
+	re_link => 'http://static.usenix.org/event/usenix99/provos/provos_html/node10.html',
     },
     CRYPT => {
         summary => 'Traditional DES crypt',
         re => qr/\A () (..) ($b64d {11}) \z/x,
         re_summary => '11 digit base64 characters',
+	re_link => 'http://perldoc.perl.org/functions/crypt.html',
     },
     SSHA256 => {
         summary => 'Salted SHA256, supported by glibc 2.7+',
         re => qr/\A (\$ 5 \$) ($b64d {0,16}) \$ ($b64d {43}) \z/x,
         re_summary => '$5$ header',
+	re_link => 'http://en.wikipedia.org/wiki/SHA-2',
     },
     SSHA512 => {
         summary => 'Salted SHA512, supported by glibc 2.7+',
         re => qr/\A (\$ 6 \$) ($b64d {0,16}) \$ ($b64d {86}) \z/x,
         re_summary => '$6$ header',
+	re_link => 'http://en.wikipedia.org/wiki/SHA-2',
     },
     BCRYPT => {
         summary => 'Passphrase scheme based on Blowfish, designed by Niels Provos and David Mazieres for OpenBSD',
         re => qr/\A (\$ 2a? \$ \d+) \$ ($b64d {22}) ($b64d {31}) \z/x,
         re_summary => '$2$ or $2a$header followed by 22 base64-digits salt and 31 digits hash',
+	re_link => 'https://www.usenix.org/legacy/event/usenix99/provos/provos_html/',
     },
     'PLAIN-MD5' => {
         summary => 'Unsalted MD5 hash, popular with PHP web applications',
         re => qr/\A () () ($hexd {32}) \z/x,
         re_summary => '32 digits of hex characters',
+	re_link => 'http://en.wikipedia.org/wiki/MD5',
     },
 );
 
@@ -124,6 +130,14 @@ sub crypt {
  say crypt('pass'); # automatically choose the appropriate type and salt
 
 
+=head1 DESCRIPTION
+
+ Crypt::Password::Util facilitates the generation and recognition of unix
+ passwords as found in /etc/shadow on Unix/Linux systems and /etc/master.passwd
+ on BSD systems.  When using crypt(), it is possible several methods will be
+ attempted before returning a result.  This is done to insure that your system
+ supports the selected hash type.
+
 =head1 FUNCTIONS
 
 =head2 crypt_type($str) => STR
@@ -131,7 +145,7 @@ sub crypt {
 Return crypt type, or undef if C<$str> does not look like a crypted password.
 Currently known types:
 
-# CODE: require Crypt::Password::Util; my $types = \%Crypt::Password::Util::CRYPT_TYPES; print "=over\n\n"; for my $type (sort keys %$types) { print "=item * $type\n\n$types->{$type}{summary}.\n\nRecognized by: $types->{$type}{re_summary}.\n\n" } print "=back\n\n";
+# CODE: require Crypt::Password::Util; my $types = \%Crypt::Password::Util::CRYPT_TYPES; print "=over\n\n"; for my $type (sort keys %$types) { print "=item * $type\n\n$types->{$type}{summary}.\n\nRecognized by: $types->{$type}{re_summary}.\n\nMore info: L<$types->{$type}{re_link}>\n\n" } print "=back\n\n";
 
 =head2 crypt_detail($str) => STR
 

--- a/t/01-basics.t
+++ b/t/01-basics.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Config;
-use Crypt::Password::Util qw(crypt_type looks_like_crypt crypt);
+use Crypt::Password::Util qw(crypt_type looks_like_crypt crypt crypt_detail);
 use Sort::Versions;
 use Test::More 0.98;
 
@@ -18,6 +18,24 @@ is( crypt_type('$6$12345678$'.("a" x 86)), "SSHA512");
 is( crypt_type('1a1dc91c907325c69271ddf0c944bc72'), "PLAIN-MD5");
 is( crypt_type('$2a$08$TTSynMjJTrXiv3qEZFyM1.H9tjv71i57p2r63QEJe/2p0p/m1GIy2'), "BCRYPT");
 ok(!crypt_type('foo'));
+
+is( crypt_detail('$$.Pw5vNt/...'), 'Type: CRYPT, Header: , Salt: $$, Hash: .Pw5vNt/...');
+is( crypt_detail('$1$$oXYGukVGYa16SN.Pw5vNt/'),
+    'Type: MD5-CRYPT, Header: $1$, Salt: , Hash: oXYGukVGYa16SN.Pw5vNt/');
+is( crypt_detail('$apr1$x$A8hldSzKARXWgJiwY6zTC.'),
+    'Type: MD5-CRYPT, Header: $apr1$, Salt: x, Hash: A8hldSzKARXWgJiwY6zTC.');
+is( crypt_detail('$apr1$12345678$A8hldSzKARXWgJiwY6zTC.'),
+    'Type: MD5-CRYPT, Header: $apr1$, Salt: 12345678, Hash: A8hldSzKARXWgJiwY6zTC.');
+is( crypt_detail('$5$123456789$'.("a" x 43)),
+    'Type: SSHA256, Header: $5$, Salt: 123456789, Hash: '.("a" x 43));
+is( crypt_detail('$6$12345678$'.("a" x 86)),
+    'Type: SSHA512, Header: $6$, Salt: 12345678, Hash: '.("a" x 86));
+is( crypt_detail('1a1dc91c907325c69271ddf0c944bc72'),
+    'Type: PLAIN-MD5, Header: , Salt: , Hash: 1a1dc91c907325c69271ddf0c944bc72');
+is( crypt_detail('$2a$08$TTSynMjJTrXiv3qEZFyM1.H9tjv71i57p2r63QEJe/2p0p/m1GIy2'),
+    'Type: BCRYPT, Header: $2a$08, Salt: TTSynMjJTrXiv3qEZFyM1., '.
+    'Hash: H9tjv71i57p2r63QEJe/2p0p/m1GIy2');
+ok(!crypt_detail('foo'));
 
 ok( looks_like_crypt('$6$12345678$'.("a" x 86)));
 ok(!looks_like_crypt('foo'));


### PR DESCRIPTION
Thank you for your feedback on my previous pull request, I learned a lot about Dist::Zilla and it's available functionality as a result.  This pull request includes a couple items from your wishlist.

*\* WISHLIST [2015-01-25 Min] cryptpwutil: (as separate function?) an option to return detailed information about a crypted string
instead of just recognizing its type, we can also parse and return its salt,
header, variant (e.g. in MD5-CRYPT there's an apache variant), or other
information.

*\* WISHLIST [2015-01-25 Min] cryptpwutil: improve documentation
    explain in first paragraph of description that this module is geared towards generation and recognition of unix passwords (/etc/shadow), that's why crypt() tries several methods but check that each method is supported by your system before returning the result.
    more pointers/links to each crypt type should a user want to find out more.
